### PR TITLE
add: keep aspect-ratio

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	_ "embed"
+	"image"
+
 	"gioui.org/app"
+	"gioui.org/f32"
 	"gioui.org/io/system"
 	"gioui.org/layout"
 	"gioui.org/op"
@@ -12,7 +15,7 @@ import (
 //go:generate go run github.com/inkeliz/giosvg/cmd/svggen -i "." -o "./school-bus.go" -pkg "main"
 
 func init() {
-	//os.Setenv("GIORENDERER", "forcecompute")
+	// os.Setenv("GIORENDERER", "forcecompute")
 }
 
 // Thanks to Freepik from Flaticon Licensed by Creative Commons 3.0 for the example icons shown below.
@@ -40,12 +43,19 @@ func main() {
 		for e := range window.Events() {
 			if e, ok := e.(system.FrameEvent); ok {
 				gtx := layout.NewContext(ops, e)
-				gtx.Constraints.Max.X, gtx.Constraints.Max.Y = 283, 283
+				gtx.Constraints.Max.X = gtx.Constraints.Max.X / 2
+				gtx.Constraints.Min = gtx.Constraints.Max
 
-				iconRuntime.Layout(gtx)
+				layout.Center.Layout(gtx, func(gtx layout.Context) layout.Dimensions {
+					gtx.Constraints.Min = image.Point{} // Keep aspect ratio.
+					return iconRuntime.Layout(gtx)
+				})
 
-				offset := op.Offset(layout.FPt(gtx.Constraints.Max)).Push(gtx.Ops)
-				iconGenerated.Layout(gtx)
+				offset := op.Offset(f32.Pt(float32(gtx.Constraints.Max.X), 0)).Push(gtx.Ops)
+				layout.Center.Layout(gtx, func(gtx layout.Context) layout.Dimensions {
+					gtx.Constraints.Min = image.Point{} // Keep aspect ratio.
+					return iconGenerated.Layout(gtx)
+				})
 				offset.Pop()
 
 				op.InvalidateOp{}.Add(gtx.Ops)

--- a/example/school-bus.go
+++ b/example/school-bus.go
@@ -1,24 +1,47 @@
 package main
 
 import (
+	"image"
+	"image/color"
+
 	"gioui.org/f32"
+	"gioui.org/layout"
 	"gioui.org/op"
 	"gioui.org/op/clip"
 	"gioui.org/op/paint"
 	"github.com/inkeliz/giosvg"
-	"image/color"
 )
 
-var _, _, _, _, _, _ = (*f32.Point)(nil), (*op.Ops)(nil), (*clip.Op)(nil), (*paint.PaintOp)(nil), (*giosvg.Vector)(nil), (*color.NRGBA)(nil)
-var VectorSchoolBus giosvg.Vector = func(ops *op.Ops, w, h float32) {
+var _, _, _, _, _, _, _ = (*f32.Point)(nil), (*op.Ops)(nil), (*clip.Op)(nil), (*paint.PaintOp)(nil), (*giosvg.Vector)(nil), (*color.NRGBA)(nil), (*layout.Dimensions)(nil)
+var VectorSchoolBus giosvg.Vector = func(ops *op.Ops, constraints giosvg.Constraints) layout.Dimensions {
+	var w, h float32
+	if constraints.Max != constraints.Min {
+
+		d := float32(1.000000)
+		if constraints.Max.Y*d > constraints.Max.X {
+			w, h = constraints.Max.X, constraints.Max.X/d
+		} else {
+			w, h = constraints.Max.Y*d, constraints.Max.Y
+		}
+	}
+
+	if constraints.Min.X > w {
+		w = constraints.Min.X
+	}
+	if constraints.Min.Y > h {
+		h = constraints.Min.Y
+	}
+
 	var (
-		aff = f32.Affine2D{}.Scale(f32.Point{X: float32(0 - 0.000000), Y: float32(0 - 0.000000)}, f32.Point{X: w / 512.001000, Y: h / 512.001000})
+		size = f32.Point{X: w / 512.001000, Y: h / 512.001000}
+		avg  = (size.X + size.Y) / 2
+		aff  = f32.Affine2D{}.Scale(f32.Point{X: float32(0 - 0.000000), Y: float32(0 - 0.000000)}, size)
 
 		end             clip.PathSpec
 		path            clip.Path
 		stroke, outline clip.Stack
 	)
-	_, _, _, _ = path, stroke, outline, end
+	_, _, _, _, _, _ = avg, aff, end, path, stroke, outline
 
 	path = clip.Path{}
 	path.Begin(ops)
@@ -1525,4 +1548,5 @@ var VectorSchoolBus giosvg.Vector = func(ops *op.Ops, w, h float32) {
 	paint.ColorOp{Color: color.NRGBA{R: 45, G: 64, B: 78, A: 255}}.Add(ops)
 	paint.PaintOp{}.Add(ops)
 	outline.Pop()
+	return layout.Dimensions{Size: image.Point{X: int(w), Y: int(h)}}
 }

--- a/giosvg.go
+++ b/giosvg.go
@@ -5,6 +5,7 @@ import (
 	"image"
 	"io"
 
+	"gioui.org/f32"
 	"gioui.org/layout"
 	"gioui.org/op"
 	"github.com/inkeliz/giosvg/internal/svgdraw"
@@ -13,7 +14,7 @@ import (
 
 // Vector hold the information from the XML/SVG file, in order to avoid
 // decoding of the XML.
-type Vector func(ops *op.Ops, w, h float32)
+type Vector func(ops *op.Ops, constraints Constraints) layout.Dimensions
 
 // Layout implements layout.Widget, that renders the current vector without any cache.
 // Consider using NewIcon instead.
@@ -21,15 +22,12 @@ type Vector func(ops *op.Ops, w, h float32)
 // You should avoid it, that functions only exists to simplify integration
 // to custom cache implementations.
 func (v Vector) Layout(gtx layout.Context) layout.Dimensions {
-	v(gtx.Ops, float32(gtx.Constraints.Max.X), float32(gtx.Constraints.Max.Y))
-	return layout.Dimensions{Size: gtx.Constraints.Max}
+	return v(gtx.Ops, newConstraintsFromGio(gtx.Constraints))
 }
 
 // NewVector creates an IconOp from the given data. The data is
 // expected to be an SVG/XML
-func NewVector(data []byte) (Vector, error) {
-	return NewVectorReader(bytes.NewReader(data))
-}
+func NewVector(data []byte) (Vector, error) { return NewVectorReader(bytes.NewReader(data)) }
 
 // NewVectorReader creates an IconOp from the given io.Reader. The data is
 // expected to be an SVG/XML
@@ -39,11 +37,54 @@ func NewVectorReader(reader io.Reader) (Vector, error) {
 		return nil, err
 	}
 
-	return func(ops *op.Ops, w, h float32) {
+	return func(ops *op.Ops, constraints Constraints) layout.Dimensions {
+		var w, h float32
+		if constraints.Max != constraints.Min {
+			if render.ViewBox.W >= render.ViewBox.H {
+				d := float32(render.ViewBox.W) / float32(render.ViewBox.H)
+				if constraints.Max.Y*d > constraints.Max.X {
+					w, h = constraints.Max.X, constraints.Max.X/d
+				} else {
+					w, h = constraints.Max.Y*d, constraints.Max.Y
+				}
+			} else {
+				d := float32(render.ViewBox.H) / float32(render.ViewBox.W)
+				if constraints.Max.X*d > constraints.Max.Y {
+					w, h = constraints.Max.Y/d, constraints.Max.Y
+				} else {
+					w, h = constraints.Max.X, constraints.Max.X*d
+				}
+			}
+		}
+
+		if constraints.Min.X > w {
+			w = constraints.Min.X
+		}
+		if constraints.Min.Y > h {
+			h = constraints.Min.Y
+		}
+
 		render.SetTarget(0-render.ViewBox.X, 0-render.ViewBox.Y, float64(w), float64(h))
-		scale := (float32(float64(w)/render.ViewBox.W) + float32(float64(h)/render.ViewBox.H)) / 2
+		scale := float32(float64(w)/render.ViewBox.W) + float32(float64(h)/render.ViewBox.H)/2
 		render.Draw(&svgdraw.Driver{Ops: ops, Scale: scale}, 1.0)
+
+		return layout.Dimensions{Size: image.Point{X: int(w), Y: int(h)}}
 	}, nil
+}
+
+// Constraints is the layout.Constraints with f32.Pt instead of image.Point.
+// This is used to keep aspect ratio, and to keep the size of the icon
+// within the constraints.
+type Constraints struct {
+	Max f32.Point
+	Min f32.Point
+}
+
+func newConstraintsFromGio(constraints layout.Constraints) Constraints {
+	return Constraints{
+		Max: f32.Pt(float32(constraints.Max.X), float32(constraints.Max.Y)),
+		Min: f32.Pt(float32(constraints.Min.X), float32(constraints.Min.Y)),
+	}
 }
 
 // Icon keeps a cache from the last frame and re-uses it if
@@ -51,9 +92,10 @@ func NewVectorReader(reader io.Reader) (Vector, error) {
 type Icon struct {
 	vector Vector
 
-	lastSize image.Point
-	macro    op.CallOp
-	op       *op.Ops
+	lastDimensions layout.Dimensions
+	lastSize       layout.Constraints
+	macro          op.CallOp
+	op             *op.Ops
 }
 
 // NewIcon creates the layout.Widget from the iconOp.
@@ -66,10 +108,8 @@ type Icon struct {
 // two Icon, for each one.
 func NewIcon(vector Vector) *Icon {
 	return &Icon{
-		vector:   vector,
-		lastSize: image.Point{},
-
-		op: new(op.Ops),
+		vector: vector,
+		op:     new(op.Ops),
 	}
 }
 
@@ -78,16 +118,16 @@ func NewIcon(vector Vector) *Icon {
 // If the SVG uses `currentColor` you can set the color using
 // paint.ColorOp.
 func (icon *Icon) Layout(gtx layout.Context) layout.Dimensions {
-	if icon.lastSize != gtx.Constraints.Max {
+	if icon.lastSize != gtx.Constraints {
 		// If the size changes, we can't re-use the macro.
-		icon.lastSize = gtx.Constraints.Max
+		icon.lastSize = gtx.Constraints
 
 		icon.op.Reset()
 		macro := op.Record(icon.op)
-		icon.vector(icon.op, float32(gtx.Constraints.Max.X), float32(gtx.Constraints.Max.Y))
+		icon.lastDimensions = icon.vector(icon.op, newConstraintsFromGio(gtx.Constraints))
 		icon.macro = macro.Stop()
 	}
 
 	icon.macro.Add(gtx.Ops)
-	return layout.Dimensions{Size: gtx.Constraints.Max}
+	return icon.lastDimensions
 }


### PR DESCRIPTION
Now, it will follow the `gtx.Constraints.Min` and `gtx.Constraints.Max`. Using
`Icon.Layout` will try to render the largest icon which keeps the aspect-ratio.

If the `gtx.Constraints.Min` is set to non-zero value, it will overwrite any
aspect-ratio. So, to use the older behavior, you must set:

`gtx.Constraints.Min = gtx.Constraints.Max`

Fixes #1